### PR TITLE
Update IT Tech Support Specialist Diploma Admissions Requirements

### DIFF
--- a/src/data/it_tech_support_specialist_programdata.json
+++ b/src/data/it_tech_support_specialist_programdata.json
@@ -3,13 +3,13 @@
         "paragraphs": [
             {
                 "style": "p",
-                "content": "A British Columbia Secondary School Diploma or equivalent with prior education in English at grade 10 level or higher OR"},
+                "content": "1. Graduated from grade 12 or equivalent (B.C. high school diploma, B.C. Adult Graduation Diploma, General Educational Development) or equivalent secondary school completion from another jurisdiction OR"},
             {
                 "style": "p",
-                "content": "Mature Student status (19 years of age or over) AND Pass the AOLCC Entrance Evaluation with 75% or higher (demonstrating both English comprehension and math skills) OR"},
+                "content": "2. 19 years of age or older before the start of classes and has demonstrated evidence at the appropriate level of literacy, numeracy, comprehension and/or written skills to enable successful completion of the program."},
             {
                 "style": "p",
-                "content": "Applicants who do not meet one of the requirements above must provide proof of English proficiency through an English language assessment (IELTS 5.5 or CELPIP 6)"}
+                "content": "3. Full-time student must attend the required hours per week as per the course schedule and may do so at times convenient to them."}
 
 
         ]

--- a/src/data/it_tech_support_specialist_programdata.json
+++ b/src/data/it_tech_support_specialist_programdata.json
@@ -6,7 +6,7 @@
                 "content": "A British Columbia Secondary School Diploma or equivalent with prior education in English at grade 10 level or higher OR"},
             {
                 "style": "p",
-                "content": "Pass the AOLCC Entrance Evaluation with 75% or higher (demonstrating both English comprehension and math skills) OR"},
+                "content": "Mature Student status (19 years of age or over) AND Pass the AOLCC Entrance Evaluation with 75% or higher (demonstrating both English comprehension and math skills) OR"},
             {
                 "style": "p",
                 "content": "Applicants who do not meet one of the requirements above must provide proof of English proficiency through an English language assessment (IELTS 5.5 or CELPIP 6)"}


### PR DESCRIPTION
SABC has requested that we update the admissions requirement for the IT Tech Support Specialist to be in compliance with the policy, ie: Require 19 years old or older.

- [ x ] Update SMORG
- [ x ] Update Program Data
- [ x ] Get Director Approval